### PR TITLE
Adding support for M2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN pear install PHP_CodeSniffer
 RUN apk update && apk upgrade && apk add --no-cache bash git openssh
 RUN git clone https://github.com/magento-ecg/coding-standard /root/
 RUN mv /root/Ecg/ /usr/local/lib/php/PHP/CodeSniffer/Standards/
+RUN mv /root/EcgM2/ /usr/local/lib/php/PHP/CodeSniffer/Standards/
 RUN phpcs --config-set default_standard Ecg


### PR DESCRIPTION
From https://github.com/magento-ecg/coding-standard

Update: Magento 2 standard just released. Try it out:

```
$ phpcs --config-set installed_paths ./vendor/magento-ecg/coding-standard
$ phpcs --standard=EcgM2 /path/to/code
```
Usage: docker run -v /root/to/local/folder/:/scripts/ phpcs --standard=EcgM2 /scripts/